### PR TITLE
Make gcc >= 6 compatible

### DIFF
--- a/CardModuleService.hpp
+++ b/CardModuleService.hpp
@@ -25,12 +25,12 @@
 
 #include <string>
 #include <boost/ptr_container/ptr_map.hpp>
+#include "Log.hpp"
 #include "MarshallerCfg.h"
 #include "Array.hpp"
 #include "Marshaller.h"
 #include "Except.h"
 #include "Timer.hpp"
-#include "Log.hpp"
 
 
 const unsigned char CARD_FREE_SPACE  = 0x00; //Returns a byte array blob of 12 bytes

--- a/MiniDriverContainer.hpp
+++ b/MiniDriverContainer.hpp
@@ -29,8 +29,8 @@
 #include <boost/serialization/version.hpp>
 #include <boost/shared_ptr.hpp>
 #include "Array.hpp"
-#include "cardmod.h"
 #include "Log.hpp"
+#include "cardmod.h"
 #include "MiniDriverAuthentication.hpp"
 
 

--- a/MiniDriverContainerMapFile.cpp
+++ b/MiniDriverContainerMapFile.cpp
@@ -22,10 +22,8 @@
 #include <cstdio>
 #include <boost/foreach.hpp>
 #include <memory>
-#include "cardmod.h"
 #include "MiniDriverContainerMapFile.hpp"
 #include "MiniDriverFiles.hpp"
-#include "Log.hpp"
 #include "Timer.hpp"
 #include "MiniDriverException.hpp"
 #include "sha1.h"

--- a/MiniDriverContainerMapFile.hpp
+++ b/MiniDriverContainerMapFile.hpp
@@ -29,9 +29,10 @@
 #include <boost/array.hpp>
 #include <boost/shared_ptr.hpp>
 #include <string>
-#include "MiniDriverContainer.hpp"
+#include "Log.hpp"
 #include "Array.hpp"
 #include "CardModuleService.hpp"
+#include "MiniDriverContainer.hpp"
 
 
 const int g_MaxContainer = 15;


### PR DESCRIPTION
These changes taken from the smartcardservices github project, should enable the compilation on newer gcc versions.
In turn this should allow for correct packaging on newer Ubuntu versions.